### PR TITLE
Refactor: Toast duplicate fix, Preference page fix, Preference props reroute

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,11 +53,11 @@ function App() {
     { path: '/terms', element: <TermsAndConditions />, name: 'Terms' },
     { path: '/callback', element: <Callback />, name: 'Callback' },
     { path: '/pricing', element: <Pricing />, name: 'Pricing' },
-    { path: '*', element: <Error404Page />, name: 'Error404' }
+    { path: '*', element: <Error404Page />, name: 'Error404' },
   ];
   const privateRoutes: RouteType[] = [
     { path: '/dashboard', element: <Dashboard />, name: 'Dashboard' },
-    { path: '/admin', element: <AdminDashboardScreen />, name: 'Admin' }
+    { path: '/admin', element: <AdminDashboardScreen />, name: 'Admin' },
   ];
 
   const activeAccount = authService.getCurrentAccount();

--- a/src/components/dashboard-sections/airport-suggestions.tsx
+++ b/src/components/dashboard-sections/airport-suggestions.tsx
@@ -23,7 +23,7 @@ export const AirportSuggestions = ({
     
 
     return (
-        <div className="absolute z-10 bg-neutral-300 border shadow-lg rounded-lg w-full overflow-hidden mt-1">
+        <div className="absolute z-10 bg-neutral-300 border shadow-lg rounded-lg w-full overflow-hidden mt-2">
             <Listbox
                 name="airportSuggestions"
                 onChange={(value) => onSelect(value)}

--- a/src/components/dashboard-sections/edit.tsx
+++ b/src/components/dashboard-sections/edit.tsx
@@ -1,7 +1,7 @@
 
 import { useEffect, useState } from "react";
 import { BsStars } from "react-icons/bs";
-import { toast } from "react-toastify";
+import { toastManager } from "../../utils/toastUtils";
 
 type EditProps = {
   message?: string | null;
@@ -14,7 +14,7 @@ export const EditData =({message, field}:EditProps)=> {
   useEffect(() => {
     if (field?.toLowerCase() === 'multi-city' || field?.toLowerCase() === 'round trip') {
       setExtraMessage('Select your return date...');
-      toast.warning('Select your return date...');
+      toastManager.show('select-date','Select your return date...','warn');
     } else {
       setExtraMessage(null);
     }

--- a/src/components/dashboard-sections/mobileRender.tsx
+++ b/src/components/dashboard-sections/mobileRender.tsx
@@ -67,7 +67,7 @@ const MobileRender: React.FC = () => {
   return (
     <>
       { mobileTab !== '' ? 
-        <div className={`absolute block bg-white lg:hidden w-screen h-screen py-8`}>
+        <div className={`absolute z-10 block bg-white lg:hidden w-screen h-svh py-8`}>
           <div className="w-screen h-full pt-10 px-4 md:px-6">
             <Suspense fallback={<LoadingScreen message={"Loading..."} dimension="w-full h-full" background="bg-background"/>}>
               {RenderPage()}

--- a/src/components/dashboard-sections/preference.tsx
+++ b/src/components/dashboard-sections/preference.tsx
@@ -31,11 +31,10 @@ export const PreferencesSection = ({
     const [activeField, setActiveField] = useState<string | null>(null);
     const [filteredSuggestions, setFilteredSuggestions] = useState<Airport[]>(airportSuggestions || []);
 
-    // Sync filteredSuggestions with airportSuggestions when it changes
     useEffect(() => {
         setFilteredSuggestions(airportSuggestions || []);
     }, [airportSuggestions]);
-    const safePreferences = preferences || {
+    const savePreferences = preferences || {
         originAirport: "",
         destinationAirport: "",
         travelClass: "Economy",
@@ -79,7 +78,7 @@ export const PreferencesSection = ({
                             id="originAirportInput"
                             type="text"
                             name="originAirport"
-                            value={safePreferences.originAirport}
+                            value={savePreferences.originAirport}
                             onChange={(e) => {
                                 onChange?.(e);
                                 onAirportInputChange?.(e.target.value);
@@ -109,7 +108,7 @@ export const PreferencesSection = ({
                             id="destinationAirportInput"
                             type="text"
                             name="destinationAirport"
-                            value={safePreferences.destinationAirport}
+                            value={savePreferences.destinationAirport}
                             onChange={(e) => {
                                 onChange?.(e);
                                 onAirportInputChange?.(e.target.value);
@@ -136,14 +135,14 @@ export const PreferencesSection = ({
                     </label>
                     <Listbox
                         name="travelClass"
-                        value={safePreferences.travelClass}
+                        value={savePreferences.travelClass}
                         onChange={(value) => {
                             onChange?.({target:{ name: 'travelClass', value }} as React.ChangeEvent<HTMLSelectElement>)
                         }}
                     >
                         <ListboxButton className="font-work flex items-center w-full border px-4 py-2 rounded-[10px] justify-between hover:bg-neutral-300 text-Neutral font-medium">
                             <span>
-                                {safePreferences.travelClass}
+                                {savePreferences.travelClass}
                             </span>
                             <MdKeyboardArrowDown />
                         </ListboxButton>
@@ -171,14 +170,14 @@ export const PreferencesSection = ({
                     </label>
                     <Listbox
                         name="stopOvers"
-                        value={safePreferences.stopOvers}
+                        value={savePreferences.stopOvers}
                         onChange={(value) => {
                             onChange?.({ target: { name: 'stopOvers', value } } as React.ChangeEvent<HTMLSelectElement>)
                         }}
                     >
                         <ListboxButton className="font-work flex items-center w-full border px-4 py-2 rounded-[10px] justify-between hover:bg-neutral-300 text-Neutral font-medium">
                             <span>
-                                {safePreferences.stopOvers}
+                                {savePreferences.stopOvers}
                             </span>
                             <MdKeyboardArrowDown />
                         </ListboxButton>

--- a/src/contexts/EditContext.tsx
+++ b/src/contexts/EditContext.tsx
@@ -25,6 +25,3 @@ export const EditContext = createContext<EditContextType>({
   multiLegValue: '',
   setMultiLegValue: () => { },
 });
-
-
-

--- a/src/hooks/useAuthEvents.ts
+++ b/src/hooks/useAuthEvents.ts
@@ -1,10 +1,10 @@
 import { useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { toast } from 'react-toastify';
 import { EventManager } from '../utils/EventManager';
 import { CustomStorage } from '../utils/customStorage';
 import { SESSION_VALUES } from '../utils/constants';
 import authService from '../services/authService';
+import { toastManager } from '../utils/toastUtils';
 
 const storage = new CustomStorage();
 
@@ -39,17 +39,17 @@ export const useAuthEvents = (options: UseAuthEventsOptions = {}) => {
 
             if (redirectUrl && redirectUrl !== location.pathname) {
                 storage.removeItem(SESSION_VALUES.postLoginRedirectUrl);
-                toast.success("Successfully signed in!");
+                toastManager.show("sign-in","Successfully signed in!","success");
                 navigate(redirectUrl);
             } else {
-                toast.success("Welcome to your dashboard!");
+                toastManager.show("welcome", "Welcome to your dashboard!", "success")
                 navigate(defaultRedirectUrl);
             }
         };
 
         const handleLoginFailure = () => {
             setIsProcessingAuth?.(false);
-            toast.error("Authentication failed. Please try again.");
+            toastManager.show("Login-failure","Authentication failed. Please try again.", "error");
             storage.removeItem(SESSION_VALUES.postLoginRedirectUrl);
 
             if (location.pathname !== '/') {

--- a/src/pages/dashboard/chats/Dashboard.tsx
+++ b/src/pages/dashboard/chats/Dashboard.tsx
@@ -2,7 +2,6 @@
 import { DateSelectArg } from "@fullcalendar/core/index.js";
 import { PenLine } from "lucide-react";
 import { ChangeEvent, KeyboardEvent, useContext, useEffect, useRef, useState } from "react";
-import { toast } from "react-toastify";
 import MobileRender from "../../../components/dashboard-sections/mobileRender";
 import Calendar from '../../../components/modals/Calendar';
 import EditModal from "../../../components/modals/EditModal";
@@ -23,6 +22,7 @@ import ChatHistory from "./ChatHistory";
 import ChatInput from "./ChatInput";
 import RecentPromptsBar from "./RecentPromptsBar";
 import SuggestionPanel from "./SuggestionPanel";
+import { toastManager } from "../../../utils/toastUtils";
 
 const analyzeLastMessage = (message?: string) => {
   if (!message) return {
@@ -63,8 +63,6 @@ const Dashboard: React.FC = () => {
   const { mobileTab } = useContext(NavigationContext);
   const { chatLog, setChatLog, recentPrompts, setRecentPrompts } = useContext(ChatContext);
   const { inputValue, setInputValue, dateSelect, setDateSelect, setDate, date } = useInput();
-
-  // Custom hooks
   const {
     showEditModal,
     setShowEditModal,
@@ -81,10 +79,6 @@ const Dashboard: React.FC = () => {
     preferences,
     fetchAirports,
     airportSuggestions,
-    preferencesLoading,
-    handlePreferenceChange,
-    handleAirportSelect,
-    savePreferences
   } = useDashboardInfo();
 
   useEffect(() => {
@@ -213,7 +207,7 @@ const Dashboard: React.FC = () => {
       updateDateSelect();
       handleCloseCalendar();
     } else {
-      toast.error('Pick a date');
+      toastManager.show('date-error','Pick a date','error');
     }
   };
 
@@ -241,6 +235,7 @@ const Dashboard: React.FC = () => {
     }
 
   };
+  
 
   const handleUpdatePrompt = (index: number, newValue: string) => {
     const updatedPrompts = [...recentPrompts];
@@ -342,15 +337,7 @@ const Dashboard: React.FC = () => {
         </Modal>
         {!isDesktop && <MobileRender />}
       </div>
-      <RightPanel
-        preferences={preferences}
-        airportSuggestions={airportSuggestions}
-        preferencesLoading={preferencesLoading}
-        handlePreferenceChange={handlePreferenceChange}
-        handleAirportSelect={handleAirportSelect}
-        savePreferences={savePreferences}
-        fetchAirports={fetchAirports}
-      />
+      <RightPanel/>
     </div>
   );
 };

--- a/src/pages/dashboard/sections/RightPanel.tsx
+++ b/src/pages/dashboard/sections/RightPanel.tsx
@@ -16,12 +16,10 @@ import { NavigationContext } from '../../../contexts/NavigationContext';
 import { NavItem } from '../../../contexts/types';
 import { UIContext } from '../../../contexts/UIContext';
 import { useAuthInfo } from '../../../hooks/useAuthInfo';
-import { Airport, UserPreferences } from '../../../hooks/useDashboardInfo';
 import { CustomStorage } from '../../../utils/customStorage';
 import LoadingScreen from '../../../components/layout/LoadingScreen';
 import { useIsDesktop } from '../../../hooks/useDesktopSize';
 import { BsChatLeftText, BsChatLeftTextFill } from 'react-icons/bs';
-
 const HomeContent = React.lazy(() => import('./HomeContent').then(module => ({ default: module.HomeContent })));
 const DesolaAI = React.lazy(() => import('./DesolaAI').then(module => ({ default: module.DesolaAI })));
 const TripHistoryContent = React.lazy(() => import('./TripHistoryContent').then(module => ({ default: module.TripHistoryContent })));
@@ -32,16 +30,6 @@ const SupportContent = React.lazy(() => import('./SupportContent').then(module =
 
 const storageService = new CustomStorage();
 
-interface RightPanelProps {
-  preferences: UserPreferences;
-  airportSuggestions: Airport[];
-  preferencesLoading: boolean;
-  handlePreferenceChange: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
-  handleAirportSelect: (airportCode: string, field: string) => void;
-  savePreferences: () => Promise<void>;
-  fetchAirports: () => Promise<void>;
-}
-
 export const GetRequiredFields = (route: string) => {
   const isOneWay = route?.toLowerCase().startsWith('one way');
   const requiredFields = ['departure', 'destination', 'departureDate', 'flightClass'];
@@ -51,15 +39,7 @@ export const GetRequiredFields = (route: string) => {
   return requiredFields;
 };
 
-export const RightPanel: React.FC<RightPanelProps> = ({
-  preferences,
-  airportSuggestions,
-  preferencesLoading,
-  handlePreferenceChange,
-  handleAirportSelect,
-  savePreferences,
-  fetchAirports
-}) => {
+export const RightPanel=() => {
 
   const { chatLog } = useContext(ChatContext);
   const [selectedTab, setSelectedTab] = useState<string>('home');
@@ -158,21 +138,6 @@ export const RightPanel: React.FC<RightPanelProps> = ({
       const Component = TAB_COMPONENTS[selectedTab as 'home'];
       return <Component {...travelInfo} />;
     }
-
-    if (selectedTab === 'user') {
-      return (
-        <UserContent
-          preferences={preferences}
-          airportSuggestions={airportSuggestions}
-          preferencesLoading={preferencesLoading}
-          handlePreferenceChange={handlePreferenceChange}
-          handleAirportSelect={handleAirportSelect}
-          savePreferences={savePreferences}
-          fetchAirports={fetchAirports}
-        />
-      );
-    }
-
     // For components that don't need props
     const Component = TAB_COMPONENTS[selectedTab as 'AI' | 'road' | 'trash' | 'subscription' | 'support'];
     return Component ? <Component departure={''} destination={''} departureDate={''} returnDate={''} travelRoute={''} flightClass={''} /> : null;

--- a/src/pages/dashboard/sections/UserContent.tsx
+++ b/src/pages/dashboard/sections/UserContent.tsx
@@ -2,31 +2,21 @@ import { PreferencesSection } from "../../../components/dashboard-sections/prefe
 import { ProfileSection } from "../../../components/dashboard-sections/profile";
 import { useAuthInfo } from "../../../hooks/useAuthInfo";
 import { Title } from "../../../components/layout/Title";
-import { Airport, UserPreferences } from "../../../hooks/useDashboardInfo";
+import { useDashboardInfo} from "../../../hooks/useDashboardInfo";
 import authService from "../../../services/authService";
 
 
-
-interface UserContentProps {
-  preferences?: UserPreferences;
-  airportSuggestions?: Airport[];
-  preferencesLoading?: boolean;
-  handlePreferenceChange?: (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
-  handleAirportSelect?: (airportCode: string, field: string) => void;
-  savePreferences?: () => Promise<void>;
-  fetchAirports?: () => Promise<void>;
-}
-
-export const UserContent: React.FC<UserContentProps> = ({
-  preferences,
-  airportSuggestions,
-  preferencesLoading,
-  handlePreferenceChange,
-  handleAirportSelect,
-  savePreferences,
-  fetchAirports
-}) => {
+export const UserContent = () => {
   const { isAuthenticated, isLoading: authLoading } = useAuthInfo();
+  const {
+      preferences,
+      fetchAirports,
+      airportSuggestions,
+      preferencesLoading,
+      handlePreferenceChange,
+      handleAirportSelect,
+      savePreferences
+  } = useDashboardInfo();
 
   if (authLoading) {
     return <div className="flex justify-center items-center h-64">

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,10 +1,11 @@
 import axios, { AxiosError, InternalAxiosRequestConfig } from "axios";
-import { toast } from "react-toastify";
+import { toastManager } from "../utils/toastUtils"; 
 import { SESSION_VALUES, VITE_API_BASE_URL, VITE_API_TOKEN } from "../utils/constants";
 import { CustomStorage } from "../utils/customStorage";
 import authService from "./authService";
 
 const storage = new CustomStorage();
+
 
 let isShowingAuthError = false;
 
@@ -58,7 +59,7 @@ apiClient.interceptors.response.use(
 
             if (!isShowingAuthError) {
                 isShowingAuthError = true;
-                toast.warn("Authentication required. Please log in again.");
+                toastManager.show("auth-error","Authentication required. Please log in again.","warn");
                 setTimeout(() => { isShowingAuthError = false; }, 3000);
 
                 window.dispatchEvent(new CustomEvent('auth:interactive-required'));
@@ -72,16 +73,17 @@ apiClient.interceptors.response.use(
                     // toast.warn("Resource not found");
                     break;
                 case 500:
-                    toast.error("Internal server error. Please contact support");
+                    toastManager.show("server-error","Internal server error. Please contact support","error");
                     break;
                 default:
                     if (status !== 401 && status !== 403) {
-                        toast.error(`Unexpected error occurred (Code: ${status})`);
+                        toastManager.show(`error-${status}`, `Unexpected error occurred (Code: ${status})`, "error");
                     }
+
             }
         } else if (error.request) {
             // Network error
-            toast.error("Network error. Please check your connection");
+            toastManager.show("network-error", "Network error. Please check your connection", "error");
         }
 
         return Promise.reject(error);

--- a/src/services/msalAuthManager.ts
+++ b/src/services/msalAuthManager.ts
@@ -7,11 +7,11 @@ import {
     PopupRequest,
     RedirectRequest
 } from "@azure/msal-browser";
-import { toast } from "react-toastify";
 import { msalInstance } from "../auth/msalConfig";
 import { AZURE_B2C, SESSION_VALUES } from "../utils/constants";
 import { CustomStorage } from "../utils/customStorage";
 import { AuthEvents, AppEvents } from "../utils/EventManager";
+import { toastManager } from "../utils/toastUtils";
 
 const storage = new CustomStorage();
 
@@ -250,7 +250,7 @@ export class MSALAuthManager {
     async signIn(): Promise<void> {
         try {
             if (this.getCurrentAccount()) {
-                toast.info("User already signed in");
+                toastManager.show("account-info","User already signed in", "info");
                 return;
             }
 
@@ -470,7 +470,7 @@ export class MSALAuthManager {
             // Handle B2C password reset flow
             if (errorMessage.includes("AADB2C90118")) {
                 console.warn("Password reset flow detected");
-                toast.info("Redirecting to password reset...");
+                toastManager.show("auth-err","Redirecting to password reset...","error");
                 this.handlePasswordReset().catch(err => {
                     console.error("Password reset redirect failed:", err);
                     AppEvents.error("Password reset failed", err.message);
@@ -489,25 +489,25 @@ export class MSALAuthManager {
             // Handle B2C policy mismatch
             if (errorMessage.includes("AADB2C90091")) {
                 console.warn("B2C policy mismatch detected");
-                toast.warn("Please complete the authentication process");
+                toastManager.show("B2C","Please complete the authentication process","warn");
                 return;
             }
 
             // Handle user cancellation
             if (errorMessage.includes("user_cancelled") || errorMessage.includes("access_denied")) {
-                toast.info("Authentication was cancelled");
+                toastManager.show("cancel-auth","Authentication was cancelled", "info");
                 return;
             }
 
             // Generic error handling
             console.error("Unhandled authentication error:", errorMessage);
             AppEvents.error("Authentication error", errorMessage);
-            toast.error(`Authentication error: ${errorMessage}`);
+            toastManager.show("unhandled-error",`Authentication error: ${errorMessage}`, "error");
 
         } catch (handlingError) {
             console.error("Error in authentication error handler:", handlingError);
             AppEvents.error("Authentication system error", "Error in error handler");
-            toast.error("Authentication system error");
+            toastManager.show("system-error","Authentication system error", "error");
         }
     }
 

--- a/src/utils/toastUtils.ts
+++ b/src/utils/toastUtils.ts
@@ -1,0 +1,25 @@
+import { toast, ToastOptions } from "react-toastify";
+
+const activeToasts: Record<string, boolean> = {};
+
+export const toastManager = {
+  show: (
+    key: string,
+    message: string,
+    type: 'info' | 'success' | 'warn' | 'error' = 'info',
+    options?: ToastOptions
+  ) => {
+    if (activeToasts[key]) return;
+
+    activeToasts[key] = true;
+
+    toast[type](message, {
+      ...options,
+      onClose: () => {
+        activeToasts[key] = false;
+        options?.onClose?.();
+      },
+      autoClose: options?.autoClose ?? 3000,
+    });
+  }
+};


### PR DESCRIPTION

I used the useDashboardInfo hook to prevent prop drilling in the preference screen.
I adjusted the toast across the board to prevent duplicate Toast notifications using a toastUtilManager.

I cached the preference endpoint to reduce API calls